### PR TITLE
fix: compatibility with Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,14 @@
     "type": "symfony-bundle",
     "license": "MIT",
     "require": {
-        "symfony/console": "^2.3|^3.0|^4.0|^5.0",
-        "symfony/framework-bundle": "^2.3|^3.0|^4.0|^5.0",
-        "symfony/process": "^2.3|^3.0|^4.0|^5.0",
-        "symfony/yaml": "^2.3|^3.0|^4.0|^5.0"
+        "php": ">=7.1",
+        "symfony/console": "^4.0|^5.0",
+        "symfony/framework-bundle": "^4.0|^5.0",
+        "symfony/process": "^4.0|^5.0",
+        "symfony/yaml": "^4.0|^5.0"
     },
     "require-dev": {
-        "symfony/var-dumper": "^2.3|^3.0|^4.0|^5.0"
+        "symfony/var-dumper": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CrontabGenerator.php
+++ b/src/CrontabGenerator.php
@@ -7,20 +7,28 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class CrontabGenerator
 {
     /**
-     * @param                    $content
-     * @param ContainerInterface $container
-     * @return string
+     * @var ContainerInterface
      */
-    public function replaceWithContainerParameters($content, ContainerInterface $container)
+    private $container;
+
+    public function __construct(ContainerInterface $container)
     {
-        return preg_replace_callback('/\{%([^\}]*)\%}/', function ($matches) use ($container) {
-            return $container->getParameter($matches[1]);
-        }, $content);
+        $this->container = $container;
     }
 
     /**
      * @param string $content
-     * @param null   $dir
+     * @return string
+     */
+    public function replaceWithContainerParameters($content)
+    {
+        return preg_replace_callback('/\{%([^\}]*)\%}/', function ($matches) {
+            return $this->container->getParameter($matches[1]);
+        }, $content);
+    }
+
+    /**
+     * @param string|null $dir
      * @return string
      */
     public function createTemporaryFile($dir = null)
@@ -32,8 +40,8 @@ class CrontabGenerator
     }
 
     /**
-     * @param $content
-     * @param $filename
+     * @param string $content
+     * @param string $filename
      * @throws \RuntimeException
      */
     public function write($content, $filename)

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,12 +12,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bentools_crontab');
+        $treeBuilder = new TreeBuilder('bentools_crontab');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()
                 ->scalarNode('dist_file')
+                ->defaultValue('%kernel.project_dir%/config/crontab.dist')
                 ->end()
             ->end();
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -4,8 +4,11 @@ services:
         class: BenTools\CrontabBundle\Command\CrontabUpdateCommand
         arguments:
             - '@BenTools\CrontabBundle\CrontabGenerator'
+            - '%bentools_crontab.dist_file%'
         tags:
             - { name: console.command }
 
     BenTools\CrontabBundle\CrontabGenerator:
         class: BenTools\CrontabBundle\CrontabGenerator
+        arguments:
+            - '@service_container'


### PR DESCRIPTION
- Change requirements in `composer.json`
- TreeBuilder needs a name in configuration
- Replace inheritance (`ContainerAwareCommand` by `Command`) and return an integer for command
- Define a default value for dist file
- Dependency injection for service container and dist file