### PR TITLE
fix: change parameter of Symfony Process

### DIFF
--- a/src/Command/CrontabUpdateCommand.php
+++ b/src/Command/CrontabUpdateCommand.php
@@ -79,7 +79,7 @@ class CrontabUpdateCommand extends Command
             }
 
             $output->write('Applying new crontab... ');
-            $process = new Process(sprintf('crontab %s', $outputFile));
+            $process = new Process(['crontab', $outputFile]);
             $process->run();
             $output->writeln('<info>Success!</info>');
         }


### PR DESCRIPTION
Symfony 5 removes deprecated string parameter in Symfony Process. (see https://github.com/symfony/process/commit/828774541181d2b90640873de86db0341542ab24)

Sorry, I forgot it in my precedent PR.

I had this error:
```
$ bin/console crontab:update
Writing crontab to /tmp/bentools_crontabBz1mvF... Success!
Update crontab on system? (Y/n): y
Applying new crontab... 
In Process.php line 141:
                                                                                                                                                                     
  [TypeError]                                                                                                                                                        
  Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in <PROJECT_PATH>/bentools/crontab-  
  bundle/src/Command/CrontabUpdateCommand.php on line 82 
```